### PR TITLE
处理歌词为空的情况

### DIFF
--- a/lyric_providers/netease.go
+++ b/lyric_providers/netease.go
@@ -3,12 +3,13 @@ package lyric_providers
 import (
 	"PlasmaDesktopLyrics/config"
 	"encoding/json"
+	"strconv"
+	"strings"
+
 	"github.com/go-musicfox/netease-music/service"
 	"github.com/go-musicfox/netease-music/util"
 	"github.com/godbus/dbus/v5"
 	"github.com/telanflow/cookiejar"
-	"strconv"
-	"strings"
 )
 
 type NetEaseLyricProvider struct{}
@@ -40,9 +41,25 @@ func (n NetEaseLyricProvider) GetLyricByMeta(musicMeta map[string]dbus.Variant) 
 	}
 	_, body := searchApi.Search()
 	var searchResult map[string]interface{}
-	_ = json.Unmarshal(body, &searchResult)
+	err := json.Unmarshal(body, &searchResult)
+	if err != nil {
+		return "", false
+	}
 
-	song := searchResult["result"].(map[string]interface{})["songs"].([]interface{})[0].(map[string]interface{})
+	result, ok := searchResult["result"].(map[string]interface{})
+	if !ok || result == nil {
+		return "", false
+	}
+
+	songs, ok := result["songs"].([]interface{})
+	if !ok || len(songs) == 0 {
+		return "", false
+	}
+
+	song, ok := songs[0].(map[string]interface{})
+	if !ok || song == nil {
+		return "", false
+	}
 
 	if strings.ToLower(song["name"].(string)) != strings.ToLower(musicMeta["xesam:title"].Value().(string)) {
 		return "", false

--- a/main.go
+++ b/main.go
@@ -7,12 +7,13 @@ import (
 	"PlasmaDesktopLyrics/mpris"
 	"PlasmaDesktopLyrics/types"
 	"encoding/json"
-	"github.com/godbus/dbus/v5"
-	"github.com/gorilla/websocket"
 	"net/http"
 	"os"
 	"slices"
 	"time"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/gorilla/websocket"
 )
 
 var (
@@ -276,8 +277,10 @@ func updateLyrics() {
 						}
 						currentLyricIdx = idx
 						// 发送歌词
-						b, _ := json.Marshal(lyrics[idx])
-						ch <- b
+						if idx < len(lyrics) {
+							b, _ := json.Marshal(lyrics[idx])
+							ch <- b
+						}
 					}
 				}
 			}


### PR DESCRIPTION
有时获取到的歌词会为空，导致读歌词时数组越界，后台服务崩溃：

```
在 http://localhost:15648 启动了桌面歌词服务器
有新的连接
panic: runtime error: index out of range [0] with length 0
goroutine 7 [running]:
main.updateLyrics()
        PlasmaDesktopLyrics/main.go:279 +0x35e
created by main.main in goroutine 1
        PlasmaDesktopLyrics/main.go:60 +0xa8
```

增加此情况的判断，如果歌词 index 超出边界就不发送歌词。